### PR TITLE
Updated change password error message to reflect new parameter format

### DIFF
--- a/Chauffeur/Deliverables/UserDeliverable.cs
+++ b/Chauffeur/Deliverables/UserDeliverable.cs
@@ -48,7 +48,7 @@ namespace Chauffeur.Deliverables
             if (args.Length != 2)
             {
                 await Out.WriteLineAsync("The expected parameters for 'change-password' were not supplied.");
-                await Out.WriteLineAsync("Format expected: change-password <User Id> <old password> <new password>");
+                await Out.WriteLineAsync("Format expected: change-password <username> <new password>");
                 return;
             }
 


### PR DESCRIPTION
Updated the error message shown when entering the wrong parameters for the change-password command to reflect the changes to the user deliverable that now uses IUserService