### PR TITLE
Add upgrade deliverable

### DIFF
--- a/Chauffeur.Tests/Chauffeur.Tests.csproj
+++ b/Chauffeur.Tests/Chauffeur.Tests.csproj
@@ -245,6 +245,7 @@
     <Compile Include="Deliverables\DeliveryDeliverableTests.cs" />
     <Compile Include="Deliverables\DictionaryDeliverableTests.cs" />
     <Compile Include="Deliverables\HelpDeliverableTests.cs" />
+    <Compile Include="Deliverables\UpgradeDeliverableTests.cs" />
     <Compile Include="Deliverables\InstallDeliverableTests.cs" />
     <Compile Include="Deliverables\PackageDeliverableTests.cs" />
     <Compile Include="Deliverables\QuitDeliverableTests.cs" />

--- a/Chauffeur.Tests/Deliverables/UpgradeDeliverableTests.cs
+++ b/Chauffeur.Tests/Deliverables/UpgradeDeliverableTests.cs
@@ -1,5 +1,11 @@
-﻿using Chauffeur.Deliverables;
+﻿using System;
+using System.Linq;
+using Chauffeur.Deliverables;
 using NSubstitute;
+using Semver;
+using Umbraco.Core;
+using Umbraco.Core.Configuration;
+using Umbraco.Core.Models;
 using Umbraco.Core.Services;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
@@ -11,15 +17,84 @@ namespace Chauffeur.Tests.Deliverables
         [Fact]
         public async Task NoMigrationEntries_WillWarnAndExit()
         {
-            var writer = new MockTextWriter();
-            var migrationEntryService = Substitute.For<IMigrationEntryService>();
-
-            var deliverable = new UpgradeDeliverable(null, writer, null, migrationEntryService);
+            var writer = Writer();
+            
+            var deliverable = new UpgradeDeliverable(null, writer, null, MigrationEntryService());
 
             var response = await deliverable.Run(null, null);
 
             Assert.Single(writer.Messages);
             Assert.Equal(DeliverableResponse.FinishedWithError, response);
+        }
+
+        [Fact]
+        public async Task SameVersions_NothingDone()
+        {
+            var writer = Writer();
+            
+            var deliverable = new UpgradeDeliverable(null, writer, null, MigrationEntryService(UmbracoVersion.GetSemanticVersion()));
+
+            var response = await deliverable.Run(null, null);
+
+            Assert.Single(writer.Messages);
+            Assert.Equal(DeliverableResponse.FinishedWithError, response);
+        }
+
+        [Fact]
+        public async Task CorrectSameVersionSelected_NothingDone()
+        {
+            var writer = Writer();
+            
+            var deliverable = new UpgradeDeliverable(null, writer, null, MigrationEntryService(new SemVersion(7, 1), UmbracoVersion.GetSemanticVersion(), new SemVersion(7,3)));
+
+            var response = await deliverable.Run(null, null);
+
+            Assert.Single(writer.Messages);
+            Assert.Equal(DeliverableResponse.FinishedWithError, response);
+        }
+
+        [Fact]
+        public async Task DifferentVersions_UpgradeIsCompleted()
+        {
+            var writer = Writer();
+            var deliverable = new UpgradeDeliverable(null, writer, Upgrader(true), MigrationEntryService(new SemVersion(7,1)));
+
+            var response = await deliverable.Run(null, null);
+
+            Assert.True(writer.Messages.Count() == 2);
+            Assert.Equal(DeliverableResponse.Continue, response);
+        }
+
+        [Fact]
+        public async Task UpgradeFailes_ErrorStateReturned()
+        {
+            var writer = Writer();
+            var deliverable = new UpgradeDeliverable(null, writer, Upgrader(false), MigrationEntryService(new SemVersion(7, 1)));
+
+            var response = await deliverable.Run(null, null);
+
+            Assert.True(writer.Messages.Count() == 2);
+            Assert.Equal(DeliverableResponse.FinishedWithError, response);
+        }
+
+        private MockTextWriter Writer()
+        {
+            return new MockTextWriter();
+        }
+        
+        private IMigrationEntryService MigrationEntryService(params SemVersion[] versions)
+        {
+            var migrationEntryService = Substitute.For<IMigrationEntryService>();
+            var entries = versions.Select(v => new MigrationEntry(1, DateTime.Now, Constants.System.UmbracoMigrationName, v));
+            migrationEntryService.GetAll(Constants.System.UmbracoMigrationName).Returns(entries);
+            return migrationEntryService;
+        }
+
+        private IUpgrader Upgrader(bool returns)
+        {
+            var upgrader = Substitute.For<IUpgrader>();
+            upgrader.Upgrade(new SemVersion(7, 1), UmbracoVersion.GetSemanticVersion()).Returns(returns);
+            return upgrader;
         }
     }
 }

--- a/Chauffeur.Tests/Deliverables/UpgradeDeliverableTests.cs
+++ b/Chauffeur.Tests/Deliverables/UpgradeDeliverableTests.cs
@@ -1,0 +1,25 @@
+﻿using Chauffeur.Deliverables;
+using NSubstitute;
+using Umbraco.Core.Services;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Chauffeur.Tests.Deliverables
+{
+    public class UpgradeDeliverableTests
+    {
+        [Fact]
+        public async Task NoMigrationEntries_WillWarnAndExit()
+        {
+            var writer = new MockTextWriter();
+	        var migrationEntryService = Substitute.For<IMigrationEntryService>();
+
+            var deliverable = new UpgradeDeliverable(null, writer, null, migrationEntryService);
+
+            var response = await deliverable.Run(null, null);
+
+            Assert.Single(writer.Messages);
+			Assert.Equal(DeliverableResponse.FinishedWithError,response);
+        }
+    }
+}

--- a/Chauffeur.Tests/Deliverables/UpgradeDeliverableTests.cs
+++ b/Chauffeur.Tests/Deliverables/UpgradeDeliverableTests.cs
@@ -12,14 +12,14 @@ namespace Chauffeur.Tests.Deliverables
         public async Task NoMigrationEntries_WillWarnAndExit()
         {
             var writer = new MockTextWriter();
-	        var migrationEntryService = Substitute.For<IMigrationEntryService>();
+            var migrationEntryService = Substitute.For<IMigrationEntryService>();
 
             var deliverable = new UpgradeDeliverable(null, writer, null, migrationEntryService);
 
             var response = await deliverable.Run(null, null);
 
             Assert.Single(writer.Messages);
-			Assert.Equal(DeliverableResponse.FinishedWithError,response);
+            Assert.Equal(DeliverableResponse.FinishedWithError, response);
         }
     }
 }

--- a/Chauffeur/Chauffeur.csproj
+++ b/Chauffeur/Chauffeur.csproj
@@ -234,6 +234,7 @@
     <Compile Include="Deliverables\DeliveryDeliverable.cs" />
     <Compile Include="Deliverables\DeliveryTrackingDeliverable.cs" />
     <Compile Include="Deliverables\DictionaryDeliverable.cs" />
+    <Compile Include="Deliverables\UpgradeDeliverable.cs" />
     <Compile Include="Deliverables\InstallDeliverable.cs" />
     <Compile Include="Deliverables\PackageDeliverable.cs" />
     <Compile Include="Deliverables\ChangeAliasDeliverable.cs" />

--- a/Chauffeur/Deliverables/UpgradeDeliverable.cs
+++ b/Chauffeur/Deliverables/UpgradeDeliverable.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Semver;
+using Umbraco.Core;
+using Umbraco.Core.Configuration;
+using Umbraco.Core.Persistence.Migrations;
+using Umbraco.Core.Services;
+
+namespace Chauffeur.Deliverables
+{
+    [DeliverableName("upgrade")]
+    public sealed class UpgradeDeliverable : Deliverable
+    {
+        private readonly ApplicationContext appContext;
+	    private readonly IMigrationEntryService migrationEntryService;
+
+		public UpgradeDeliverable(
+            TextReader reader,
+            TextWriter writer,
+            ApplicationContext appContext,
+			IMigrationEntryService migrationEntryService
+            )
+            : base(reader, writer)
+        {
+            this.appContext = appContext;
+	        this.migrationEntryService = migrationEntryService;
+
+        }
+
+        public override async Task<DeliverableResponse> Run(string command, string[] args)
+        {
+	        try
+	        {
+		        var currentVersion = FindCurrentDbVersion();
+		        await Out.WriteLineAsync(
+			        $"Attempting to upgrade from {currentVersion} to {UmbracoVersion.GetSemanticVersion()}");
+
+		        var runner = new MigrationRunner(
+			        migrationEntryService,
+			        appContext.ProfilingLogger.Logger, 
+			        currentVersion, 
+			        UmbracoVersion.GetSemanticVersion(),
+			        Constants.System.UmbracoMigrationName);
+
+		        var upgraded = runner.Execute(appContext.DatabaseContext.Database, isUpgrade:true);
+
+		        if (upgraded == false)
+		        {
+			        await base.Out.WriteLineAsync("Upgrading failed, see log for full details");
+			        return DeliverableResponse.FinishedWithError;
+		        }
+
+		        await base.Out.WriteLineAsync("Upgrading completed");
+		        return DeliverableResponse.Continue;
+	        }
+	        catch (NoConfiguredVersionException)
+	        {
+		        await base.Out.WriteLineAsync("Can't upgrade as there is no configured version");
+		        return DeliverableResponse.FinishedWithError;
+	        }
+		}
+
+	    private SemVersion FindCurrentDbVersion()
+	    {
+		    var entries = migrationEntryService.GetAll(Constants.System.UmbracoMigrationName).ToArray();
+		    if (entries.Any())
+		    {
+			    return entries.OrderBy(e => e.Version).Last().Version;
+		    }
+			throw new NoConfiguredVersionException();
+	    }
+    }
+
+	public class NoConfiguredVersionException : Exception
+	{
+
+	}
+}

--- a/Chauffeur/Deliverables/UpgradeDeliverable.cs
+++ b/Chauffeur/Deliverables/UpgradeDeliverable.cs
@@ -14,67 +14,67 @@ namespace Chauffeur.Deliverables
     public sealed class UpgradeDeliverable : Deliverable
     {
         private readonly ApplicationContext appContext;
-	    private readonly IMigrationEntryService migrationEntryService;
+        private readonly IMigrationEntryService migrationEntryService;
 
-		public UpgradeDeliverable(
+        public UpgradeDeliverable(
             TextReader reader,
             TextWriter writer,
             ApplicationContext appContext,
-			IMigrationEntryService migrationEntryService
+            IMigrationEntryService migrationEntryService
             )
             : base(reader, writer)
         {
             this.appContext = appContext;
-	        this.migrationEntryService = migrationEntryService;
+            this.migrationEntryService = migrationEntryService;
 
         }
 
         public override async Task<DeliverableResponse> Run(string command, string[] args)
         {
-	        try
-	        {
-		        var currentVersion = FindCurrentDbVersion();
-		        await Out.WriteLineAsync(
-			        $"Attempting to upgrade from {currentVersion} to {UmbracoVersion.GetSemanticVersion()}");
+            try
+            {
+                var currentVersion = FindCurrentDbVersion();
+                await Out.WriteLineAsync(
+                    $"Attempting to upgrade from {currentVersion} to {UmbracoVersion.GetSemanticVersion()}");
 
-		        var runner = new MigrationRunner(
-			        migrationEntryService,
-			        appContext.ProfilingLogger.Logger, 
-			        currentVersion, 
-			        UmbracoVersion.GetSemanticVersion(),
-			        Constants.System.UmbracoMigrationName);
+                var runner = new MigrationRunner(
+                    migrationEntryService,
+                    appContext.ProfilingLogger.Logger,
+                    currentVersion,
+                    UmbracoVersion.GetSemanticVersion(),
+                    Constants.System.UmbracoMigrationName);
 
-		        var upgraded = runner.Execute(appContext.DatabaseContext.Database, isUpgrade:true);
+                var upgraded = runner.Execute(appContext.DatabaseContext.Database, isUpgrade: true);
 
-		        if (upgraded == false)
-		        {
-			        await base.Out.WriteLineAsync("Upgrading failed, see log for full details");
-			        return DeliverableResponse.FinishedWithError;
-		        }
+                if (upgraded == false)
+                {
+                    await base.Out.WriteLineAsync("Upgrading failed, see log for full details");
+                    return DeliverableResponse.FinishedWithError;
+                }
 
-		        await base.Out.WriteLineAsync("Upgrading completed");
-		        return DeliverableResponse.Continue;
-	        }
-	        catch (NoConfiguredVersionException)
-	        {
-		        await base.Out.WriteLineAsync("Can't upgrade as there is no configured version");
-		        return DeliverableResponse.FinishedWithError;
-	        }
-		}
+                await base.Out.WriteLineAsync("Upgrading completed");
+                return DeliverableResponse.Continue;
+            }
+            catch (NoConfiguredVersionException)
+            {
+                await base.Out.WriteLineAsync("Can't upgrade as there is no configured version");
+                return DeliverableResponse.FinishedWithError;
+            }
+        }
 
-	    private SemVersion FindCurrentDbVersion()
-	    {
-		    var entries = migrationEntryService.GetAll(Constants.System.UmbracoMigrationName).ToArray();
-		    if (entries.Any())
-		    {
-			    return entries.OrderBy(e => e.Version).Last().Version;
-		    }
-			throw new NoConfiguredVersionException();
-	    }
+        private SemVersion FindCurrentDbVersion()
+        {
+            var entries = migrationEntryService.GetAll(Constants.System.UmbracoMigrationName).ToArray();
+            if (entries.Any())
+            {
+                return entries.OrderBy(e => e.Version).Last().Version;
+            }
+            throw new NoConfiguredVersionException();
+        }
     }
 
-	public class NoConfiguredVersionException : Exception
-	{
+    public class NoConfiguredVersionException : Exception
+    {
 
-	}
+    }
 }

--- a/Chauffeur/Deliverables/UpgradeDeliverable.cs
+++ b/Chauffeur/Deliverables/UpgradeDeliverable.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using Semver;
 using Umbraco.Core;
+using Umbraco.Core.Logging;
 using Umbraco.Core.Configuration;
+using Umbraco.Core.Persistence;
 using Umbraco.Core.Persistence.Migrations;
 using Umbraco.Core.Services;
 
@@ -13,20 +15,19 @@ namespace Chauffeur.Deliverables
     [DeliverableName("upgrade")]
     public sealed class UpgradeDeliverable : Deliverable
     {
-        private readonly ApplicationContext appContext;
+        private readonly IUpgrader upgrader;
         private readonly IMigrationEntryService migrationEntryService;
 
         public UpgradeDeliverable(
             TextReader reader,
             TextWriter writer,
-            ApplicationContext appContext,
+            IUpgrader upgrader,
             IMigrationEntryService migrationEntryService
             )
             : base(reader, writer)
         {
-            this.appContext = appContext;
+            this.upgrader = upgrader;
             this.migrationEntryService = migrationEntryService;
-
         }
 
         public override async Task<DeliverableResponse> Run(string command, string[] args)
@@ -34,17 +35,16 @@ namespace Chauffeur.Deliverables
             try
             {
                 var currentVersion = FindCurrentDbVersion();
-                await Out.WriteLineAsync(
-                    $"Attempting to upgrade from {currentVersion} to {UmbracoVersion.GetSemanticVersion()}");
+                var targetVersion = UmbracoVersion.GetSemanticVersion();
 
-                var runner = new MigrationRunner(
-                    migrationEntryService,
-                    appContext.ProfilingLogger.Logger,
-                    currentVersion,
-                    UmbracoVersion.GetSemanticVersion(),
-                    Constants.System.UmbracoMigrationName);
+                if (currentVersion == targetVersion)
+                {
+                    await Out.WriteLineAsync($"Version is up to date {currentVersion} no work todo");
+                    return DeliverableResponse.FinishedWithError;
+                }
 
-                var upgraded = runner.Execute(appContext.DatabaseContext.Database, isUpgrade: true);
+                await Out.WriteLineAsync($"Upgrading from {currentVersion} to {targetVersion}");
+                var upgraded = upgrader.Upgrade(currentVersion, targetVersion);
 
                 if (upgraded == false)
                 {
@@ -76,5 +76,37 @@ namespace Chauffeur.Deliverables
     public class NoConfiguredVersionException : Exception
     {
 
+    }
+
+    public interface IUpgrader
+    {
+        bool Upgrade(SemVersion from, SemVersion to);
+    }
+
+    public class Upgrader : IUpgrader
+    {
+        
+        private ILogger logger;
+        private IMigrationEntryService migrationEntryService;
+        private UmbracoDatabase database;
+
+        public Upgrader(IMigrationEntryService migrationEntryService, ILogger logger, UmbracoDatabase database)
+        {
+            this.logger = logger;
+            this.migrationEntryService = migrationEntryService;
+            this.database = database;
+        }
+
+        public bool Upgrade(SemVersion from, SemVersion to)
+        {
+            var runner = new MigrationRunner(
+                migrationEntryService,
+                logger,
+                from,
+                to,
+                Constants.System.UmbracoMigrationName);
+
+            return runner.Execute(database, isUpgrade: true);
+        }
     }
 }

--- a/Chauffeur/DependencyBuilders/BootManagerBuilder.cs
+++ b/Chauffeur/DependencyBuilders/BootManagerBuilder.cs
@@ -33,8 +33,8 @@ namespace Chauffeur.DependencyBuilders
             container.Register(() => services.MemberGroupService);
             container.Register(() => services.MemberService);
             container.Register(() => services.MemberTypeService);
-	        container.Register(() => services.MigrationEntryService);
-			container.Register(() => new OverridingPackagingService(services.PackagingService, services.MacroService, services.DataTypeService, services.ContentTypeService))
+            container.Register(() => services.MigrationEntryService);
+            container.Register(() => new OverridingPackagingService(services.PackagingService, services.MacroService, services.DataTypeService, services.ContentTypeService))
                 .As<IPackagingService>();
             container.Register(() => services.UserService);
         }

--- a/Chauffeur/DependencyBuilders/BootManagerBuilder.cs
+++ b/Chauffeur/DependencyBuilders/BootManagerBuilder.cs
@@ -33,7 +33,8 @@ namespace Chauffeur.DependencyBuilders
             container.Register(() => services.MemberGroupService);
             container.Register(() => services.MemberService);
             container.Register(() => services.MemberTypeService);
-            container.Register(() => new OverridingPackagingService(services.PackagingService, services.MacroService, services.DataTypeService, services.ContentTypeService))
+	        container.Register(() => services.MigrationEntryService);
+			container.Register(() => new OverridingPackagingService(services.PackagingService, services.MacroService, services.DataTypeService, services.ContentTypeService))
                 .As<IPackagingService>();
             container.Register(() => services.UserService);
         }

--- a/Chauffeur/Services/IMigrationRunnerService.cs
+++ b/Chauffeur/Services/IMigrationRunnerService.cs
@@ -1,0 +1,9 @@
+﻿using Semver;
+
+namespace Chauffeur.Services
+{
+	public interface IMigrationRunnerService
+	{
+		bool Execute(SemVersion from, SemVersion to);
+	}
+}

--- a/Chauffeur/Services/MigrationRunnerService.cs
+++ b/Chauffeur/Services/MigrationRunnerService.cs
@@ -1,0 +1,37 @@
+﻿using Semver;
+using Umbraco.Core;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.Migrations;
+using Umbraco.Core.Services;
+
+namespace Chauffeur.Services
+{
+	
+
+	public class MigrationRunnerService : IMigrationRunnerService
+	{
+		private ILogger logger;
+		private IMigrationEntryService migrationEntryService;
+		private UmbracoDatabase database;
+
+		public MigrationRunnerService(IMigrationEntryService migrationEntryService, ILogger logger, UmbracoDatabase database)
+		{
+			this.logger = logger;
+			this.migrationEntryService = migrationEntryService;
+			this.database = database;
+		}
+
+		public bool Execute(SemVersion from, SemVersion to)
+		{
+			var runner = new MigrationRunner(
+				migrationEntryService,
+				logger,
+				from,
+				to,
+				Constants.System.UmbracoMigrationName);
+
+			return runner.Execute(database, isUpgrade: true);
+		}
+	}
+}


### PR DESCRIPTION
Add a deliverable which will run the database migrations for upgrades. 

This will allow DB upgrades to be done unattended. Which in a CI scenario will mean that a deployment system will be able to upgrade Umbraco sites and not need to run the Umbraco installer on all environments.