### PR TITLE
Add  pending upgrade check

### DIFF
--- a/Chauffeur.Tests.Integration/UpgradeDeliverable.fs
+++ b/Chauffeur.Tests.Integration/UpgradeDeliverable.fs
@@ -29,3 +29,17 @@ type ``Upgrade Umbraco``() =
 
             x.TextWriter.Messages |> should haveLength 1
         } |> Async.RunSynchronously
+        
+    [<Fact>]
+    member x.``Upgrade will return a message saying there is no pending upgrade``() =
+        async {
+            let! _ = x.InstallUmbraco() |> Async.AwaitTask
+        
+            x.TextWriter.Flush()
+        
+            let! response = x.Host.Run([| "upgrade check" |]) |> Async.AwaitTask
+        
+            response |> should equal DeliverableResponse.FinishedWithError
+            x.TextWriter.Messages |> should haveLength 1
+        } |> Async.RunSynchronously
+               

--- a/Chauffeur/Deliverables/UpgradeDeliverable.cs
+++ b/Chauffeur/Deliverables/UpgradeDeliverable.cs
@@ -47,7 +47,17 @@ namespace Chauffeur.Deliverables
 
             var targetVersion = UmbracoVersion.GetSemanticVersion();
 
-            if (currentVersion == targetVersion)
+            bool sameVersion = currentVersion == targetVersion;
+
+            if (args?.Length == 1 && string.Compare(args[0], "check", true) == 0)
+            {
+                await Out.WriteLineAsync(sameVersion ?
+                    $"There is no pending upgrade. Umbraco is up to date {currentVersion}"
+                    : $"There is a pending upgrade. Umbraco upgrade from {currentVersion} to {targetVersion}");
+                return sameVersion ? DeliverableResponse.FinishedWithError : DeliverableResponse.Continue;
+            }
+
+            if (sameVersion)
             {
                 await Out.WriteLineAsync($"Version is up to date {currentVersion} no work todo");
                 return DeliverableResponse.FinishedWithError;

--- a/docs/available-deliverables.md
+++ b/docs/available-deliverables.md
@@ -18,4 +18,5 @@ The following Deliverables ship in the box with Chauffeur:
 * [Scaffold](deliverable-scaffold.md)
 * [Settings](deliverable-settings.md)
 * [Unknown](deliverable-unknown.md)
+* [Upgrade](deliverable-upgrade.md)
 * [User](deliverable-user.md)

--- a/docs/deliverable-upgrade.md
+++ b/docs/deliverable-upgrade.md
@@ -12,3 +12,11 @@ Upgrades the Umbraco database from one release to another using the internal Umb
 ## Usage
 
     umbraco> upgrade
+
+# Check pending upgrade
+
+Checks if there is an upgrade waiting to be installed.
+
+## Usage
+
+    umbraco> upgrade check


### PR DESCRIPTION
This pull request is built on top of the Upgrade deliverable.

It allows checking if there is a pending upgrade, without really executing. This is useful in a CI scenario where the Umbraco upgrade will be done unattended but some actions must be done beforehand, such as displaying a static maintenance page while the upgrade is being done. 